### PR TITLE
add fixmee-measure-urgency-function

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,9 @@ character.  For example, one might write `FIXMEEEEEEEEE` for an
 important issue.  The `fixmee-goto-nextmost-urgent` command will
 navigate to the longest notice first.
 
+Alternatively, a user-specified function can provided for determining
+urgency by setting a value for `fixmee-measure-urgency-function`.
+
 To use fixmee-mode, add the following to your `~/.emacs` file
 
 ```elisp

--- a/fixmee.el
+++ b/fixmee.el
@@ -362,6 +362,17 @@ text."
   "Face to show \"fixme\" notices"
   :group 'fixmee)
 
+(defcustom fixmee-measure-urgency-function 'fixmee-measure-urgency
+  "Function used to calculate urgency ranking.
+
+Function should accept a single string value, the match
+value from `fixmee-notice-regexp', and return an
+integer value.
+
+The function must not change the match data."
+   :type 'function
+   :group 'fixmee)
+
 ;;;###autoload
 (defgroup fixmee-global nil
   "Settings for `global-fixmee-mode'."
@@ -1014,7 +1025,7 @@ characters of STR-VAL are always ignored."
                                            (save-match-data
                                              (nth 4 (syntax-ppss (match-beginning 1)))))) ; point is within a comment
                               (push (list
-                                     (fixmee-measure-urgency raw-match)
+                                     (funcall fixmee-measure-urgency-function raw-match)
                                      (current-buffer)
                                      (match-beginning 1)
                                      (match-end 1))


### PR DESCRIPTION
Adds the defcustom fixmee-measure-urgency-function to allow the user to specify an alternate function for determining the urgency for each notice.